### PR TITLE
Upgrade Jetty to 9.4.30.v20200611

### DIFF
--- a/multiplexing-examples/jetty-client/pom.xml
+++ b/multiplexing-examples/jetty-client/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <main.class>de.consol.labs.h2c.examples.client.jetty.JettyClientExample</main.class>
-        <jetty.version>9.3.4.v20151007</jetty.version>
+        <jetty.version>9.4.30.v20200611</jetty.version>
     </properties>
 
 


### PR DESCRIPTION
9.3 version does not support closing of streams correctly even though in this code header is created with end of stream flag. This is an issue when I tried to send multiple messages using this example. 9.4 corrects this.